### PR TITLE
Fix bug in Pokedex card image

### DIFF
--- a/pokedex/script.js
+++ b/pokedex/script.js
@@ -47,7 +47,7 @@ const createPokemonCard = (pokemon) => {
 
     const pokemonInnerHTML = `
     <div class="img-container">
-        <img src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png"" alt="${name}">
+        <img src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png" alt="${name}">
     </div>
     <div class="info">
         <span class="number">#${id}</span>


### PR DESCRIPTION
## Summary
- fix invalid HTML in `pokedex/script.js` causing double quotes inside the image tag

## Testing
- `node --check pokedex/script.js`
